### PR TITLE
No need for sudo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - src toolchain add sourcegraph.com/sourcegraph/srclib-python
   - go get -d -v ./... && go build -v ./...
   - make test-dependencies
+  - export PATH=$PATH:$HOME/.local/bin
   - make install
 
 # TODO(sqs): add `go test`

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 all: install update-dockerfile
 
 install:
+	./set_path.sh
 	@mkdir -p .bin
 	go get -d ./...
 	go build -o .bin/srclib-python

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ install:
 	@mkdir -p .bin
 	go get -d ./...
 	go build -o .bin/srclib-python
-	sudo pip install -r requirements.txt --upgrade
-	sudo pip install . --upgrade
+	pip install -r requirements.txt --upgrade --user
+	pip install . --upgrade --user
 
 test-dependencies:
-	sudo pip install -r .test.requirements.txt --upgrade
+	pip install -r .test.requirements.txt --upgrade --user
 
 update-dockerfile:
 	src toolchain build sourcegraph.com/sourcegraph/srclib-python
 
 install-docker:
 	go install .
-	pip install -r requirements.txt --upgrade
-	pip install . --upgrade
+	pip install -r requirements.txt --upgrade --user
+	pip install . --upgrade --user

--- a/grapher/graph.py
+++ b/grapher/graph.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import json
@@ -51,7 +52,7 @@ def graph_wrapper(dir_, pretty=False, verbose=False, quiet=False, nSourceFilesTr
         all_data['Refs'].extend(data['Refs'])
 
     json_indent = 2 if pretty else None
-    print json.dumps(all_data, indent=json_indent)
+    print(json.dumps(all_data, indent=json_indent))
 
 
 def graph(dir_, source_files, pretty=False, verbose=False, quiet=False):
@@ -118,10 +119,10 @@ def graph(dir_, source_files, pretty=False, verbose=False, quiet=False):
             unique_refs.append(ref)
 
     json_indent = 2 if pretty else None
-    print json.dumps({
+    print(json.dumps({
         'Defs': [d.__dict__ for d in unique_defs],
         'Refs': [r.__dict__ for r in unique_refs],
-    }, indent=json_indent)
+    }, indent=json_indent))
 
 def get_source_files(dir_):
     source_files = []

--- a/set_path.sh
+++ b/set_path.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+USRBIN=${HOME}/local/bin
+
+
+if [[ ":${PATH}:" == *":${USRBIN}:"* ]]; then 
+	echo $USRBIN already in path
+else
+	echo adding $USRBIN to your path in .bashrc and appending to '$PATH' now
+	echo 'export PATH=$PATH:'$USRBIN >> $HOME/.bashrc
+    export PATH=$PATH:$USRBIN 
+fi


### PR DESCRIPTION
Remove sudo which is not needed, and actually prevent people to install things as non-root.

If really want to install as root, one can use `sudo ./src toolchain install-std`