### PR TITLE
Windows support

### DIFF
--- a/python/grapher.go
+++ b/python/grapher.go
@@ -295,6 +295,9 @@ func (c *GraphContext) inferSourceUnitFromFile(file string, reqs []*requirement)
 		if cmp == "lib" && prev == ".env"  {
 			pythonDirIdx = i
 			break
+		} else if strings.EqualFold(cmp, "lib") && strings.HasPrefix(strings.ToLower(prev), "python")  {
+			pythonDirIdx = i
+			break
 		}
 		prev = cmp
 	}

--- a/python/util.go
+++ b/python/util.go
@@ -31,10 +31,7 @@ func runCmdStderr(cmd *exec.Cmd) error {
 // In `docker` mode, it will return empty string because there is no virtualenv.
 func getProgramPath() (string, error) {
 	if dockerEnv == "" {
-		path, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(os.Args[0]), ".."))
-		if err != nil {
-			return ``, err
-		}
+		path := filepath.Join(filepath.Dir(os.Args[0]), "..")
 		return filepath.Abs(path)
 	}
 	return "", nil


### PR DESCRIPTION
- dealing with the case when project and virtual env are located on different drives (unable to construct relative path then)
- when computing span offsets, taking into account possible multibyte line feeds, otherwise project cloned using CRLF as line separators may produce incorrect offsets
- when resolving program path, there is no need to evaluate symlinks (which also may cause issues on Windows)
- dealing with the case when some components are taken from "regular" Python installation, (python.../Lib)